### PR TITLE
Add client message

### DIFF
--- a/src/main/java/fuzs/sneakycurses/config/ClientConfig.java
+++ b/src/main/java/fuzs/sneakycurses/config/ClientConfig.java
@@ -17,8 +17,6 @@ public class ClientConfig extends AbstractConfig {
     public boolean shiftShows = false;
     @Config(name = "notify_player_of_decurse_by_wear", description = "Send a message to the client chat to inform the player that an item has been decursed by using or wearing it.")
     public boolean notifyClientOfDecurseByWear = true;
-    @Config(name = "notify_player_of_decurse_by_anvil", description = "Send a message to the client chat to inform the player that an item has been decursed using an anvil.")
-    public boolean notifyClientOfDecurseByAnvil = false;
 
     @SuppressWarnings("deprecation")
     public ClientConfig() {

--- a/src/main/java/fuzs/sneakycurses/config/ClientConfig.java
+++ b/src/main/java/fuzs/sneakycurses/config/ClientConfig.java
@@ -15,6 +15,10 @@ public class ClientConfig extends AbstractConfig {
     public boolean affectBooks = false;
     @Config(name = "shift_shows_curses", description = "Temporarily show tooltip as usual including curses while shift key is held.")
     public boolean shiftShows = false;
+    @Config(name = "notify_player_of_decurse_by_wear", description = "Send a message to the client chat to inform the player that an item has been decursed by using or wearing it.")
+    public boolean notifyClientOfDecurseByWear = true;
+    @Config(name = "notify_player_of_decurse_by_anvil", description = "Send a message to the client chat to inform the player that an item has been decursed using an anvil.")
+    public boolean notifyClientOfDecurseByAnvil = false;
 
     @SuppressWarnings("deprecation")
     public ClientConfig() {

--- a/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -16,10 +16,10 @@ public class ServerConfig extends AbstractConfig {
     @Config(name = "material_cost_for_revealing_curses_in_anvil", description = "Amount of experience levels required to make curses on an item visible by combining with an item from the 'sneakycurses:reveal_curses' tag (amethyst shards by default) in an anvil.")
     @Config.IntRange(min = 1)
     public int revealCursesCost = 5;
-    @Config(name = "tick_interval_for_possible_reveal_during_usage", description = "The tick interval at which the equipped slot is attempted to be decursed.")
+    @Config(name = "tick_interval_for_possible_reveal_during_usage", description = "The tick interval at which a piece of equipement is attempted to be decursed. The probability that an item is decursed during an attempt depends on the 'curse_reveal_chance' value.")
     @Config.IntRange(min = 1)
     public int revealChanceTickInterval = 1200;
-    @Config(description = "Chance wearing or using a cursed piece of equipment will trigger the curses to be revealed. Set to 0.0 to disable revealing curses this way.")
+    @Config(name = "curse_reveal_chance", description = "Chance wearing or using a cursed piece of equipment will trigger the curses to be revealed. Set to 0.0 to disable revealing curses this way.")
     @Config.DoubleRange(min = 0.0, max = 1.0)
     public double curseRevealChance = 0.05;
 

--- a/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -16,6 +16,9 @@ public class ServerConfig extends AbstractConfig {
     @Config(name = "material_cost_for_revealing_curses_in_anvil", description = "Amount of experience levels required to make curses on an item visible by combining with an item from the 'sneakycurses:reveal_curses' tag (amethyst shards by default) in an anvil.")
     @Config.IntRange(min = 1)
     public int revealCursesCost = 5;
+    @Config(name = "tick_interval_for_possible_reveal_during_usage", description = "The tick interval at which the equipped slot is attempted to be decursed.")
+    @Config.IntRange(min = 1)
+    public int revealChanceTickInterval = 1200;
     @Config(description = "Chance wearing or using a cursed piece of equipment will trigger the curses to be revealed. Set to 0.0 to disable revealing curses this way.")
     @Config.DoubleRange(min = 0.0, max = 1.0)
     public double curseRevealChance = 0.05;

--- a/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
+++ b/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
@@ -5,8 +5,10 @@ import fuzs.puzzleslib.api.event.v1.data.MutableInt;
 import fuzs.puzzleslib.api.event.v1.data.MutableValue;
 import fuzs.sneakycurses.SneakyCurses;
 import fuzs.sneakycurses.init.ModRegistry;
+import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -57,13 +59,12 @@ public class CurseRevealHandler {
                         revealAllCurses(itemStack);
                         entity.playSound(SoundEvents.ENCHANTMENT_TABLE_USE, 1.0F,
                                 entity.getRandom().nextFloat() * 0.1F + 0.9F);
-                        // TODO: Fix displaying message.
-                        // if (entity instanceof Player player) {
-                        // player.displayClientMessage(
-                        // Component.translatable(KEY_ITEM_CURSES_REVEALED, itemStack.getDisplayName())
-                        // .withStyle(ChatFormatting.DARK_PURPLE),
-                        // false);
-                        // }
+                        if (entity instanceof Player player) {
+                            player.displayClientMessage(
+                                    new TranslatableComponent(KEY_ITEM_CURSES_REVEALED, itemStack.getDisplayName())
+                                            .withStyle(ChatFormatting.DARK_PURPLE),
+                                    false);
+                        }
                         break;
                     }
                 }

--- a/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
+++ b/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
@@ -40,12 +40,6 @@ public class CurseRevealHandler {
             output.accept(itemStack);
             materialCost.accept(1);
             enchantmentCost.accept(SneakyCurses.CONFIG.server().revealCursesCost);
-            if (SneakyCurses.CONFIG.client().notifyClientOfDecurseByAnvil) {
-                player.displayClientMessage(
-                        new TranslatableComponent(KEY_ITEM_CURSES_REVEALED, itemStack.getDisplayName())
-                                .withStyle(ChatFormatting.DARK_PURPLE),
-                        false);
-            }
             return EventResult.INTERRUPT;
         }
         return EventResult.PASS;

--- a/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
+++ b/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
@@ -40,6 +40,12 @@ public class CurseRevealHandler {
             output.accept(itemStack);
             materialCost.accept(1);
             enchantmentCost.accept(SneakyCurses.CONFIG.server().revealCursesCost);
+            if (SneakyCurses.CONFIG.client().notifyClientOfDecurseByAnvil) {
+                player.displayClientMessage(
+                        new TranslatableComponent(KEY_ITEM_CURSES_REVEALED, itemStack.getDisplayName())
+                                .withStyle(ChatFormatting.DARK_PURPLE),
+                        false);
+            }
             return EventResult.INTERRUPT;
         }
         return EventResult.PASS;
@@ -61,7 +67,8 @@ public class CurseRevealHandler {
                         revealAllCurses(itemStack);
                         entity.playSound(SoundEvents.ENCHANTMENT_TABLE_USE, 1.0F,
                                 entity.getRandom().nextFloat() * 0.1F + 0.9F);
-                        if (entity instanceof Player player) {
+                        if (entity instanceof Player player
+                                && SneakyCurses.CONFIG.client().notifyClientOfDecurseByWear) {
                             player.displayClientMessage(
                                     new TranslatableComponent(KEY_ITEM_CURSES_REVEALED, itemStack.getDisplayName())
                                             .withStyle(ChatFormatting.DARK_PURPLE),

--- a/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
+++ b/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
@@ -48,7 +48,9 @@ public class CurseRevealHandler {
     @SuppressWarnings("deprecation")
     public static EventResult onLivingTick(LivingEntity entity) {
         Level level = entity.getLevel();
-        if (!level.isClientSide && entity.tickCount % 1200 == 0
+        // if (!level.isClientSide && entity.tickCount % 1200 == 0
+        if (!level.isClientSide && entity.tickCount % SneakyCurses.CONFIG
+                .server().revealChanceTickInterval == 0
                 && (!(entity instanceof Player player) || !player.getAbilities().invulnerable)) {
             for (EquipmentSlot equipmentSlot : EquipmentSlot.values()) {
                 ItemStack itemStack = entity.getItemBySlot(equipmentSlot);

--- a/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
+++ b/src/main/java/fuzs/sneakycurses/handler/CurseRevealHandler.java
@@ -48,7 +48,6 @@ public class CurseRevealHandler {
     @SuppressWarnings("deprecation")
     public static EventResult onLivingTick(LivingEntity entity) {
         Level level = entity.getLevel();
-        // if (!level.isClientSide && entity.tickCount % 1200 == 0
         if (!level.isClientSide && entity.tickCount % SneakyCurses.CONFIG
                 .server().revealChanceTickInterval == 0
                 && (!(entity instanceof Player player) || !player.getAbilities().invulnerable)) {

--- a/src/main/resources/assets/sneakycurses/lang/en_us.json
+++ b/src/main/resources/assets/sneakycurses/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.sneakycurses.curses_revealed": "Curses revealed for %s."
+}


### PR DESCRIPTION
### Added

- Added back translatable client chat message announcing a de-curse. This can be turned off in the configuration.

### Changed

- Made interval between decurse attempts configurable.